### PR TITLE
Add dependabot and automerge configuration - closes #3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "04:00"
+  open-pull-requests-limit: 1
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "04:00"
+  open-pull-requests-limit: 2

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,19 @@
+name: Merge me test dependencies!
+
+on:
+  workflow_run:
+    types:
+      - completed
+    workflows:
+      # List all required workflow names here.
+      - 'Run linters'
+      - 'Run tests'
+      - 'Run tests on macos'
+      - 'Test build package'
+
+jobs:
+  automerge:
+    uses: fizyk/actions-reuse/.github/workflows/automerge-shared.yml@v2.0.0
+    secrets:
+      app_id: ${{ secrets.MERGE_APP_ID }}
+      private_key: ${{ secrets.MERGE_APP_PRIVATE_KEY }}

--- a/newsfragments/3.misc.rst
+++ b/newsfragments/3.misc.rst
@@ -1,0 +1,1 @@
+Added dependabot configuration and automerge workflow


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number