### PR TITLE
Remove editable resizer installation - dependabot fails on it anyway

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,6 @@ name = "pypi"
 [packages]
 click = "*"
 pillow = "*"
-resizer = {editable = true, path = "."}
 
 [dev-packages]
 pdbpp = "==0.10.3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4f0344f867a3092f5ee2ce4069d6ccf10b66b442e5c10f3a63fcdcf84ad8c919"
+            "sha256": "d438d3168fa03f7cd8d7c15d570d9c7d0a3eee5352d45fd812a1c64f38ddfe1f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -95,10 +95,6 @@
             ],
             "index": "pypi",
             "version": "==9.5.0"
-        },
-        "resizer": {
-            "editable": true,
-            "path": "."
         }
     },
     "develop": {

--- a/newsfragments/15.misc.rst
+++ b/newsfragments/15.misc.rst
@@ -1,0 +1,1 @@
+Removed resizer editable installation from Pipfile. It breaks dependabot.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Init file for pytest to pick up resizer dependency."""


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number