### PR TITLE
Print out image size (bytes) changes summary after resize

### DIFF
--- a/newsfragments/28.feature.rst
+++ b/newsfragments/28.feature.rst
@@ -1,0 +1,1 @@
+Print size change in summary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ select = [
   "F",   # pyflakes
   "I",   # isort
   "D",   # pydocstyle
+  "RUF", # Ruff specific
 ]
 
 [tool.mypy]

--- a/resizer/tools.py
+++ b/resizer/tools.py
@@ -1,0 +1,10 @@
+"""Additional tools to use."""
+
+
+def sizeof_fmt(num, suffix="B"):
+    """Format sizes with proper unit."""
+    for unit in ("", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"):
+        if abs(num) < 1024.0:
+            return f"{num:3.1f}{unit}{suffix}"
+        num /= 1024.0
+    return f"{num:.1f}Yi{suffix}"


### PR DESCRIPTION
Chore that needs to be done:

* [ ] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number